### PR TITLE
Fix for OSGi metatype xml generation

### DIFF
--- a/src/main/groovy/be/jlrhome/gradle/scr/GenerateDescriptorTask.groovy
+++ b/src/main/groovy/be/jlrhome/gradle/scr/GenerateDescriptorTask.groovy
@@ -118,7 +118,7 @@ class GenerateDescriptorTask extends DefaultTask {
 
             project.logger.debug(" --> Updating Service-Component value with {}", sb.toString())
             project.jar.manifest.instruction("Service-Component", sb.toString())
-            project.jar.from(project.fileTree(dir: scrOptions.getOutputDirectory(), includes:["OSGI-INF/*"]))
+            project.jar.from(project.fileTree(dir: scrOptions.getOutputDirectory()))
         }
     }
 


### PR DESCRIPTION
This fixes an issue with OSGi metatype xml descriptions being generated but not copied into the build jar file. The OSGI-INF/metatype folder was always empty.